### PR TITLE
The http.Client used to change membership now properly handles TLS

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -132,7 +132,13 @@ func (l *Layer) changeMemberhip(kind raftmembership.ChangeRequestKind, addr stri
 	var err error
 	for remaining > 0 {
 		start := time.Now()
-		client := &http.Client{Timeout: remaining}
+		dial := func(network, addr string) (net.Conn, error) {
+			return l.dial(addr, remaining)
+		}
+		client := &http.Client{
+			Timeout:   remaining,
+			Transport: &http.Transport{Dial: dial},
+		}
 		response, err = httpClientDo(client, request)
 
 		// If we got a system or network error, just return it.

--- a/layer_test.go
+++ b/layer_test.go
@@ -237,7 +237,7 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 	defer server.Close()
 
 	addr := server.Listener.Addr()
-	layer := rafthttp.NewLayer("/", addr, nil, nil)
+	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
 	err := layer.Join(addr.String(), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
@@ -250,7 +250,7 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 // If there's a network failure while leaving, an error is returned.
 func TestLayer_LeaveNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
-	layer := rafthttp.NewLayer("/", addr, nil, nil)
+	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
 	err := layer.Leave(addr.String(), time.Second)
 	if err == nil {
 		t.Fatal("Leave call did not fail")
@@ -260,7 +260,7 @@ func TestLayer_LeaveNetworkError(t *testing.T) {
 // If there's a network failure while joining, an error is returned.
 func TestLayer_JoinNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
-	layer := rafthttp.NewLayer("/", addr, nil, nil)
+	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
 	err := layer.Join(addr.String(), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
@@ -277,7 +277,7 @@ func TestLayer_JoinLocationParseError(t *testing.T) {
 	defer server.Close()
 
 	addr := server.Listener.Addr()
-	layer := rafthttp.NewLayer("/", addr, nil, nil)
+	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
 	if err := layer.Join(addr.String(), time.Second); err == nil {
 		t.Fatal("Join call did not fail")
 	}
@@ -295,7 +295,7 @@ func TestLayer_JoinRetryIfServiceUnavailable(t *testing.T) {
 	defer server.Close()
 
 	addr := server.Listener.Addr()
-	layer := rafthttp.NewLayer("/", addr, nil, nil)
+	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
 	if err := layer.Join(addr.String(), time.Second); err != nil {
 		t.Fatalf("Join request failed although it was supposed to retry: %v", err)
 	}

--- a/layer_test.go
+++ b/layer_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/CanonicalLtd/raft-http"
+	"github.com/hashicorp/raft"
 )
 
 // The Accept method receives connections from the conns channel.
@@ -238,7 +239,7 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Join(addr.String(), time.Second)
+	err := layer.Join(raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
 	}
@@ -251,7 +252,7 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 func TestLayer_LeaveNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Leave(addr.String(), time.Second)
+	err := layer.Leave(raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Leave call did not fail")
 	}
@@ -261,7 +262,7 @@ func TestLayer_LeaveNetworkError(t *testing.T) {
 func TestLayer_JoinNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Join(addr.String(), time.Second)
+	err := layer.Join(raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
 	}
@@ -278,7 +279,7 @@ func TestLayer_JoinLocationParseError(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	if err := layer.Join(addr.String(), time.Second); err == nil {
+	if err := layer.Join(raftAddress(addr), time.Second); err == nil {
 		t.Fatal("Join call did not fail")
 	}
 }
@@ -296,7 +297,12 @@ func TestLayer_JoinRetryIfServiceUnavailable(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	if err := layer.Join(addr.String(), time.Second); err != nil {
+	if err := layer.Join(raftAddress(addr), time.Second); err != nil {
 		t.Fatalf("Join request failed although it was supposed to retry: %v", err)
 	}
+}
+
+// Covert a net.Addr to raft.ServerAddress
+func raftAddress(addr net.Addr) raft.ServerAddress {
+	return raft.ServerAddress(addr.String())
 }


### PR DESCRIPTION
It re-uses the dialer set in the layer configuration.