### PR TITLE
Add support for server identities

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -55,19 +55,19 @@ func Example() {
 	rafttest.WaitLeader(t, rafts[0], time.Second)
 
 	// Request that the second node joins the cluster.
-	if err := layers[1].Join(transports[0].LocalAddr(), time.Second); err != nil {
-		log.Fatal(err)
+	if err := layers[1].Join("1", transports[0].LocalAddr(), time.Second); err != nil {
+		log.Fatalf("joining server 1 failed: %v", err)
 	}
 
 	// Request that the third node joins the cluster, contacting
 	// the non-leader node 1. The request will be automatically
 	// redirected to node 0.
-	if err := layers[2].Join(transports[1].LocalAddr(), time.Second); err != nil {
+	if err := layers[2].Join("2", transports[1].LocalAddr(), time.Second); err != nil {
 		log.Fatal(err)
 	}
 
 	// Rquest that the third node leaves the cluster.
-	if err := layers[2].Leave(transports[2].LocalAddr(), time.Second); err != nil {
+	if err := layers[2].Leave("2", transports[2].LocalAddr(), time.Second); err != nil {
 		log.Fatal(err)
 	}
 

--- a/layer_test.go
+++ b/layer_test.go
@@ -239,11 +239,11 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Join(raftAddress(addr), time.Second)
+	err := layer.Join("1", raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
 	}
-	if err.Error() != fmt.Sprintf("peer join failed: http code 404 '404 page not found'") {
+	if err.Error() != fmt.Sprintf("server join failed: http code 404 '404 page not found'") {
 		t.Fatalf("Got unexpected error: %v", err)
 	}
 }
@@ -252,7 +252,7 @@ func TestLayer_JoinErrorStatusCode(t *testing.T) {
 func TestLayer_LeaveNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Leave(raftAddress(addr), time.Second)
+	err := layer.Leave("1", raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Leave call did not fail")
 	}
@@ -262,7 +262,7 @@ func TestLayer_LeaveNetworkError(t *testing.T) {
 func TestLayer_JoinNetworkError(t *testing.T) {
 	addr := &net.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0}
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	err := layer.Join(raftAddress(addr), time.Second)
+	err := layer.Join("1", raftAddress(addr), time.Second)
 	if err == nil {
 		t.Fatal("Join call did not fail")
 	}
@@ -279,7 +279,7 @@ func TestLayer_JoinLocationParseError(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	if err := layer.Join(raftAddress(addr), time.Second); err == nil {
+	if err := layer.Join("1", raftAddress(addr), time.Second); err == nil {
 		t.Fatal("Join call did not fail")
 	}
 }
@@ -297,7 +297,7 @@ func TestLayer_JoinRetryIfServiceUnavailable(t *testing.T) {
 
 	addr := server.Listener.Addr()
 	layer := rafthttp.NewLayer("/", addr, nil, rafthttp.NewDialTCP())
-	if err := layer.Join(raftAddress(addr), time.Second); err != nil {
+	if err := layer.Join("1", raftAddress(addr), time.Second); err != nil {
 		t.Fatalf("Join request failed although it was supposed to retry: %v", err)
 	}
 }


### PR DESCRIPTION
The raft package from hashicorp has introduced server IDs in version
1.0, which allow to decouple a server's identity from its network
address.

This branch changes the raft-http APIs to take server IDs into
account when joining/leaving a cluster.